### PR TITLE
Correcting `isLoading` prop processing

### DIFF
--- a/src/LoadingMiddleware.jsx
+++ b/src/LoadingMiddleware.jsx
@@ -23,10 +23,9 @@ const LoadingMiddleware = ({ children, isLoading = false }) => {
 
     useEffect(() => {
         if (!isFirstRender.current) {
-            // didn't use start() to skip unnecessary topbar triggering
-            if (isLoading)
-                setLoading(true);
-            else
+            if (isLoading && !loading)
+                start();
+            else if (loading)
                 done();
         } else {
             isFirstRender.current = false;


### PR DESCRIPTION
Hi,

Under some circumstances it is required to show top bar when something is loading in background _outside_ of switch context, e.g. application-wide modal content loading located out of <Switch /> context.

Perhaps this is a breaking change so if you think this change should be done under different property just let me know.