### PR TITLE
Replace interface with types to support statically known members

### DIFF
--- a/packages/react-router-loading/lib/Route.tsx
+++ b/packages/react-router-loading/lib/Route.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { Route as OriginalRoute, RouteProps as OriginalRouteProps } from 'react-router';
 
-interface RouteProps extends OriginalRouteProps {
+type RouteProps = OriginalRouteProps & {
   loading?: boolean;
 }
 

--- a/packages/react-router-loading/lib/utils.ts
+++ b/packages/react-router-loading/lib/utils.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { matchRoutes, RouteObject, Location } from 'react-router';
 
-export interface LoadingRouteObject extends RouteObject {
+export type LoadingRouteObject = RouteObject & {
   loading?: boolean;
 }
 


### PR DESCRIPTION
As per [issue 30](https://github.com/victortrusov/react-router-loading/issues/30), it turns out that the inheritance is not taking place properly due to the following error after further investigation:

>> An interface can only extend an object type or intersection of object types with statically known members

My solution was to replace the interfaces with types and allow inheriting an intersection of objects.